### PR TITLE
Improve Readability of Logging Messages

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -224,9 +224,9 @@ function Invoke-Ahk2Exe {
         [string]$Compression = 'upx',
         [string]$ResourceId
     )
-    $previousHeader = Set-MessageHeader "Build-($Out)"
+    $previousHeader = Set-MessageHeader "Ahk2Exe-Compile"
 
-    Show-Message "Converting $In to $Out..." $StyleAction
+    Show-Message "Compiling $In to $Out..." $StyleAction
 
     $ahk2exe_args = "/silent verbose /in `"$In`""
     $ahk2exe_args += " /base `"$Base`""

--- a/action.ps1
+++ b/action.ps1
@@ -16,7 +16,8 @@ function Set-MessageHeader {
     param (
         [string]$header
     )
-    $oldHeader, $MessageHeader = $MessageHeader, $header
+    $oldHeader = $MessageHeader
+    $MessageHeader = $header
     return $oldHeader
 }
 
@@ -261,7 +262,7 @@ function Invoke-Action {
     }
 
     Invoke-Ahk2Exe -Path "$ahk2exePath" -Base "$ahkPath" -In "$env:In" -Out "$env:Out" -Icon "$env:Icon" -Compression "$env:Compression" -ResourceId "$env:ResourceId"
-    Show-Message "Finished" "" $StyleStatus
+    Show-Message "Finished" $StyleStatus
 }
 	
 Invoke-Action

--- a/action.ps1
+++ b/action.ps1
@@ -51,6 +51,8 @@ function Get-GitHubReleaseAssets {
     if (Test-Path -Path $downloadFolder) { 
         if ((Get-ChildItem -Path "$downloadFolder" | Measure-Object).Count -gt 0) {
             Show-Message "$displayPath is already present, skipping re-download..." $StyleQuiet
+
+            [void](Set-MessageHeader $previousHeader)
             return $downloadFolder
         }
     }
@@ -128,6 +130,8 @@ function Install-AutoHotkey {
     $installPath = (Get-ChildItem -Path $downloadFolder -Recurse | Where-Object { $_.Name -match "^$searchFilter$" } | Select-Object -First 1)
     if ([System.IO.File]::Exists($installPath)) { 
         Show-Message "Autohotkey is already installed, skipping re-installation..." $StyleQuiet
+
+        [void](Set-MessageHeader $previousHeader)
         return $installPath
     }
 
@@ -154,6 +158,8 @@ function Install-Ahk2Exe {
     $installPath = (Get-ChildItem -Path $downloadFolder -Recurse -Filter $exeName | Select-Object -First 1)
     if ([System.IO.File]::Exists($installPath)) { 
         Show-Message "Ahk2Exe is already installed, skipping re-installation..." $StyleQuiet
+
+        [void](Set-MessageHeader $previousHeader)
         return $installPath
     }
 
@@ -184,6 +190,8 @@ function Install-UPX {
     $installPath = Join-Path $ahk2exeFolder $exeName
     if ([System.IO.File]::Exists($installPath)) {
         Show-Message "UPX is already installed, skipping re-installation..." $StyleQuiet
+
+        [void](Set-MessageHeader $previousHeader)
         return
     }
 
@@ -251,7 +259,7 @@ function Invoke-Ahk2Exe {
 }
 
 function Invoke-Action {
-    Show-Message "Starting..." "" $StyleAction
+    Show-Message "Starting..." $StyleAction
     
     $ahkPath = Install-AutoHotkey
     $ahk2exePath = Install-Ahk2Exe

--- a/action.ps1
+++ b/action.ps1
@@ -16,6 +16,7 @@ function Set-MessageHeader {
     param (
         [string]$header
     )
+
     $oldHeader, $global:MessageHeader = $MessageHeader, $header
     return $oldHeader
 }
@@ -26,6 +27,7 @@ function Show-Message {
         [string]$message_style = $PSStyle.Foreground.White,
         [string]$header_style = $StyleInfo
     )
+
     Write-Host "$header_style$global:MessageHeader::$($PSStyle.Reset) " -NoNewLine
     Write-Host "$message_style$message$($PSStyle.Reset)"
 }
@@ -36,8 +38,6 @@ function Get-GitHubReleaseAssets {
         [string]$ReleaseTag = 'latest',
         [string]$FileTypeFilter
     )
-
-    
 
     $repositoryOwner, $repositoryName = ($Repository -split "/")[0, 1]
     if ([string]::IsNullOrEmpty($repositoryOwner)) { Throw "Invalid repository path, missing repository owner."}
@@ -179,6 +179,7 @@ function Install-UPX {
     param (
         [string]$Ahk2ExePath
     )
+
     $previousHeader = Set-MessageHeader "Install-UPX"
 
     Show-Message "Installing..." $StyleAction
@@ -224,6 +225,7 @@ function Invoke-Ahk2Exe {
         [string]$Compression = 'upx',
         [string]$ResourceId
     )
+
     $previousHeader = Set-MessageHeader "Compile-Ahk2Exe"
 
     Show-Message "Compiling $In to $Out..." $StyleAction
@@ -260,7 +262,7 @@ function Invoke-Ahk2Exe {
 
 function Invoke-Action {
     Show-Message "Starting..." $StyleAction
-    
+
     $ahkPath = Install-AutoHotkey
     $ahk2exePath = Install-Ahk2Exe
 

--- a/action.ps1
+++ b/action.ps1
@@ -224,7 +224,7 @@ function Invoke-Ahk2Exe {
         [string]$Compression = 'upx',
         [string]$ResourceId
     )
-    $previousHeader = Set-MessageHeader "Ahk2Exe-Compile"
+    $previousHeader = Set-MessageHeader "Compile-Ahk2Exe"
 
     Show-Message "Compiling $In to $Out..." $StyleAction
 
@@ -252,7 +252,7 @@ function Invoke-Ahk2Exe {
     if ($process.ExitCode -ne 0) {
         Throw "Exception occurred during build."
     } else {
-        Show-Message "Build completed" $StyleStatus
+        Show-Message "Compilation completed" $StyleStatus
     }
 
     [void](Set-MessageHeader $previousHeader)

--- a/action.ps1
+++ b/action.ps1
@@ -11,13 +11,12 @@ $StyleCommand = $PSStyle.Foreground.Yellow
 $StyleQuiet = $PSStyle.Foreground.BrightBlack
 
 
-$MessageHeader = "ahk2exe-action"
+$global:MessageHeader = "ahk2exe-action"
 function Set-MessageHeader {
     param (
         [string]$header
     )
-    $oldHeader = $MessageHeader
-    $MessageHeader = $header
+    $oldHeader, $global:MessageHeader = $MessageHeader, $header
     return $oldHeader
 }
 
@@ -27,7 +26,7 @@ function Show-Message {
         [string]$message_style = $PSStyle.Foreground.White,
         [string]$header_style = $StyleInfo
     )
-    Write-Host "$header_style$MessageHeader::$($PSStyle.Reset) " -NoNewLine
+    Write-Host "$header_style$global:MessageHeader::$($PSStyle.Reset) " -NoNewLine
     Write-Host "$message_style$message$($PSStyle.Reset)"
 }
 

--- a/action.ps1
+++ b/action.ps1
@@ -271,5 +271,5 @@ function Invoke-Action {
     Invoke-Ahk2Exe -Path "$ahk2exePath" -Base "$ahkPath" -In "$env:In" -Out "$env:Out" -Icon "$env:Icon" -Compression "$env:Compression" -ResourceId "$env:ResourceId"
     Show-Message "Finished" $StyleStatus
 }
-	
+
 Invoke-Action

--- a/action.yaml
+++ b/action.yaml
@@ -83,7 +83,7 @@ runs:
   steps:
     - name: Build
       shell: pwsh
-      run: ${{ github.action_path }}/action.ps1
+      run: ${{ github.action_path }}\action.ps1
       env:
         In: "${{ inputs.in }}"
         Out: "${{ inputs.out }}"


### PR DESCRIPTION
Introduces a global $MessageHeader, so we don't have to supply the message header every time we call `Show-Message`. I think this improves readability.

Also fixes:
- https://github.com/benmusson/ahk2exe-action/issues/6
- https://github.com/benmusson/ahk2exe-action/issues/7
