### PR TITLE
Add BinMod.exe support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
           ahk-tag: v1.1.37.02
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Test v1.1 x64
+      - name: Test v1.1 x86
         uses: ./
         with:
           in: .\testing\v1.1.ahk
@@ -110,6 +110,28 @@ jobs:
           target: x86
           ahk-tag: v1.1.37.02
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test v2.0 w/ BinMod
+        uses: ./
+        with:
+          in: .\testing\v2.0_binmod.ahk
+          out: .\output\v2.0_binmod_x64.exe
+          icon: .\testing\icons\test.ico
+          compression: upx
+          target: x64
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test v1.1 w/ BinMod
+        uses: ./
+        with:
+          in: .\testing\v1.1_binmod.ahk
+          out: .\output\v1.1_binmod_x64.exe
+          icon: .\testing\icons\test.ico
+          compression: upx
+          target: x64
+          ahk-tag: v1.1.37.02
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: Check for Failed Test
         run: |
@@ -122,7 +144,9 @@ jobs:
             [System.IO.File]::Exists('.\output\v2.0_x86_resourceid.exe') &&
             [System.IO.File]::Exists('.\output\v2.0_x64_tagged.exe') &&
             [System.IO.File]::Exists('.\output\v1.1_x86.exe') &&
-            [System.IO.File]::Exists('.\output\v1.1_x64.exe')
+            [System.IO.File]::Exists('.\output\v1.1_x64.exe') &&
+            [System.IO.File]::Exists('.\output\v2.0_x64_binmod.exe') &&
+            [System.IO.File]::Exists('.\output\v1.1_x64_binmod.exe')
           ) {
             Write-Output "$($PSStyle.Foreground.Green)All Tests Passed!$($PSStyle.Reset)" 
           } else {

--- a/action.ps1
+++ b/action.ps1
@@ -49,7 +49,7 @@ function Get-GitHubReleaseAssets {
 
     $downloadFolderName = $displayPath.Split([IO.Path]::GetInvalidFileNameChars()) -join '_'
     $downloadFolder = Join-Path $PathDownloads $downloadFolderName
-    if (Test-Path -Path $downloadFolder) { 
+    if (Test-Path -Path $downloadFolder) {
         if ((Get-ChildItem -Path "$downloadFolder" | Measure-Object).Count -gt 0) {
             Show-Message "$displayPath is already present, skipping re-download..." $StyleQuiet
 
@@ -67,7 +67,7 @@ function Get-GitHubReleaseAssets {
     Show-Message "Getting release information..." $StyleAction
     $headers = @{ "User-Agent" = "PowerShell-ahk2exe-action" }
     if (![string]::IsNullOrEmpty($env:GitHubToken)) { $headers["Authorization"] = "token $env:GitHubToken" }
-    
+
     $release = Invoke-RestMethod -Uri $apiUrl -Method Get -Headers $headers
 
     $assets = $release.assets
@@ -115,24 +115,24 @@ function Invoke-UnzipAllInPlace {
 
 function Install-AutoHotkey {
     $previousHeader = Set-MessageHeader "Install-Autohotkey"
-    
+
     Show-Message "Installing..." $StyleAction
     $downloadFolder = Get-GitHubReleaseAssets -Repository "$env:AutoHotkeyRepo" -ReleaseTag "$env:AutoHotkeyTag" -FileTypeFilter "*.zip"
 
     switch ($env:Target) {
-        'x64' { 
-            $exeName = 'AutoHotkey64.exe' 
+        'x64' {
+            $exeName = 'AutoHotkey64.exe'
             $searchFilter = 'AutoHotkey(U)?64\.exe'
         }
-        'x86' { 
-            $exeName = 'AutoHotkey32.exe' 
+        'x86' {
+            $exeName = 'AutoHotkey32.exe'
             $searchFilter = 'AutoHotkey(U)?32\.exe'
         }
         Default { Throw "Unsupported Architecture: '$target'. Valid Options: x64, x86" }
     }
 
     $installPath = (Get-ChildItem -Path $downloadFolder -Recurse | Where-Object { $_.Name -match "^$searchFilter$" } | Select-Object -First 1)
-    if ([System.IO.File]::Exists($installPath)) { 
+    if ([System.IO.File]::Exists($installPath)) {
         Show-Message "Autohotkey is already installed, skipping re-installation..." $StyleQuiet
 
         [void](Set-MessageHeader $previousHeader)
@@ -160,7 +160,7 @@ function Install-Ahk2Exe {
     $exeName = 'Ahk2Exe.exe'
 
     $installPath = (Get-ChildItem -Path $downloadFolder -Recurse -Filter $exeName | Select-Object -First 1)
-    if ([System.IO.File]::Exists($installPath)) { 
+    if ([System.IO.File]::Exists($installPath)) {
         Show-Message "Ahk2Exe is already installed, skipping re-installation..." $StyleQuiet
 
         [void](Set-MessageHeader $previousHeader)
@@ -190,7 +190,7 @@ function Install-UPX {
     $downloadFolder = Get-GitHubReleaseAssets -Repository "$env:UPXRepo" -ReleaseTag "$env:UPXTag" -FileTypeFilter "*win64.zip"
 
     $exeName = 'upx.exe'
-    $ahk2exeFolder = Split-Path -Path $Ahk2ExePath -Parent 
+    $ahk2exeFolder = Split-Path -Path $Ahk2ExePath -Parent
 
     $installPath = Join-Path $ahk2exeFolder $exeName
     if ([System.IO.File]::Exists($installPath)) {
@@ -239,13 +239,13 @@ function Invoke-Ahk2Exe {
 
     Switch ($compression) {
         'none' { $ahk2exe_args += " /compress 0" }
-        'upx'  { $ahk2exe_args += " /compress 2" } 
+        'upx'  { $ahk2exe_args += " /compress 2" }
         Default { Throw "Unsupported Compression Type: '$compression'. Valid Options: none, upx"}
     }
 
-    if (![string]::IsNullOrEmpty($Out)) { 
+    if (![string]::IsNullOrEmpty($Out)) {
         [void](New-Item -Path $Out -ItemType File -Force)
-        $ahk2exe_args += " /out `"$Out`"" 
+        $ahk2exe_args += " /out `"$Out`""
     }
     $ahk2exe_args += if (![string]::IsNullOrEmpty($Icon)) { " /icon `"$Icon`"" }
     $ahk2exe_args += if (![string]::IsNullOrEmpty($ResourceId)) { " /resourceid `"$ResourceId`"" }
@@ -267,8 +267,8 @@ function Invoke-Ahk2Exe {
 function Invoke-Action {
     Show-Message "Starting..." $StyleAction
 
-    if ([string]::IsNullOrEmpty($env:GitHubToken)) { 
-        Show-Message "GitHubToken environment variable is not set. API calls may be rate limited." $StyleAlert 
+    if ([string]::IsNullOrEmpty($env:GitHubToken)) {
+        Show-Message "GitHubToken environment variable is not set. API calls may be rate limited." $StyleAlert
     }
 
     $ahkPath = Install-AutoHotkey

--- a/testing/v1.1_binmod.ahk
+++ b/testing/v1.1_binmod.ahk
@@ -1,0 +1,5 @@
+#Requires AutoHotkey v1.1
+
+;@Ahk2Exe-PostExec BinMod.exe "%A_WorkFileName%"
+
+MsgBox "Compiled using benmusson/ahk2exe-action."

--- a/testing/v2.0_binmod.ahk
+++ b/testing/v2.0_binmod.ahk
@@ -1,0 +1,5 @@
+#Requires AutoHotkey v2.0
+
+;@Ahk2Exe-PostExec BinMod.exe "%A_WorkFileName%"
+
+MsgBox "Compiled using benmusson/ahk2exe-action."


### PR DESCRIPTION
Fixes (#14)

Retrieves BinMod.ahk and compiles (using Ahk2Exe) from the same sha as the ahk2exe release selected.

Doesn't require any configuration (this is done in code using `;@Ahk2Exec-PostExec`, see https://www.autohotkey.com/docs/v2/misc/Ahk2ExeDirectives.htm#PostExec).
https://github.com/AutoHotkey/Ahk2Exe/blob/master/BinMod.ahk